### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -9,6 +9,8 @@
         _paq.push(['enableLinkTracking']);
         (function() {
             var u=(('https:' == document.location.protocol) ? 'https' : 'http') + '://{{ config.pluginsConfig.piwik.URL }}';
+            // Ensure URL ends with slash
+            if (u.slice(-1) !== '/') u+='/';
             _paq.push(['setTrackerUrl', u+'piwik.php']);
             _paq.push(['setSiteId', {{ config.pluginsConfig.piwik.siteId }}]);
             var d=document,

--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,28 @@
+{% extends template.self %}
+
+{% block javascript %}
+    {{ super() }}
+
+    <script type="text/javascript">
+        var _paq = _paq || [];
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+            var u=(('https:' == document.location.protocol) ? 'https' : 'http') + '://{{ config.pluginsConfig.piwik.URL }}';
+            _paq.push(['setTrackerUrl', u+'piwik.php']);
+            _paq.push(['setSiteId', {{ config.pluginsConfig.piwik.siteId }}]);
+            var d=document,
+                g=d.createElement('script'),
+                s=d.getElementsByTagName('script')[0];
+            g.type='text/javascript';
+            g.defer=true;
+            g.async=true;
+            g.src=u+'piwik.js';
+            s.parentNode.insertBefore(g,s);
+        })();
+    </script>
+    <noscript>
+        <p><img src="http://{{ config.pluginsConfig.piwik.URL }}piwik.php?idsite={{ config.pluginsConfig.piwik.siteId }}"
+                style="border:0;" alt="" /></p>
+    </noscript>
+{% endblock %}

--- a/book/plugin.js
+++ b/book/plugin.js
@@ -1,13 +1,5 @@
 require(["gitbook"], function(gitbook) {
-    gitbook.events.bind("start", function(e, config) {
-        config.piwik = config.piwik || {};
-    });
-
     gitbook.events.bind("page.change", function() {
        _paq.push(['trackPageView']);
-    });
-
-    gitbook.events.bind("exercise.submit", function(e, data) {
-
     });
 });

--- a/index.js
+++ b/index.js
@@ -3,23 +3,6 @@ module.exports = {
         assets: "./book",
         js: [
             "plugin.js"
-        ],
-        html: {
-            "body:end": function() {
-                var config = this.options.pluginsConfig.piwik || {};
-                if (!config.siteId) throw "Need to option 'siteId' for Piwik plugin";
-                if (!config.URL) throw "Need to option 'URL' for Piwik plugin";
-                
-                return "<script type=\"text/javascript\">"
-                + "var _paq = _paq || [];_paq.push(['trackPageView']);_paq.push(['enableLinkTracking']);"
-                + "(function() {"
-                + "var u=((\"https:\" == document.location.protocol) ? \"https\" : \"http\") + \"://"
-                + config.URL + "\";_paq.push(['setTrackerUrl', u+'piwik.php']);_paq.push(['setSiteId', " + config.siteId + "]);"
-                + "var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript';"
-                + "g.defer=true; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);"
-                + "})();</script><noscript><p><img src=\"http://" + config.URL + "piwik.php?idsite=" + config.siteId
-                + "\" style=\"border:0;\" alt=\"\" /></p></noscript>";
-            }
-        }
+        ]
     }
 };

--- a/package.json
+++ b/package.json
@@ -14,5 +14,19 @@
     "license": "Apache 2",
     "bugs": {
         "url": "https://github.com/emmanuel-keller/gitbook-plugin-piwik/issues"
+    },
+    "gitbook": {
+        "properties": {
+            "URL": {
+                "type": "string",
+                "description": "Piwik instance URL",
+                "required": true
+            },
+            "siteId": {
+                "type": "string",
+                "description": "Site Tracking ID",
+                "required": true
+            }
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
                 "required": true
             },
             "siteId": {
-                "type": "string",
+                "type": "number",
                 "description": "Site Tracking ID",
                 "required": true
             }


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version and directly includes the script using GitBook 3 templating. I also embedded the plugin configuration in `package.json` which allows GitBook to perform validation before running and provides informations to users on [plugins.gitbook.com](https://plugins.gitbook.com).

Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

If you release a new version, please upgrade the gitbook engine in `package.json`:
```JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan