### PR TITLE
Use same protocol as website for loading pixel check

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -24,7 +24,7 @@
         })();
     </script>
     <noscript>
-        <p><img src="http://{{ config.pluginsConfig.piwik.URL }}{{ config.pluginsConfig.piwik.phpPath }}?idsite={{ config.pluginsConfig.piwik.siteId }}"
+        <p><img src="//{{ config.pluginsConfig.piwik.URL }}{{ config.pluginsConfig.piwik.phpPath }}?idsite={{ config.pluginsConfig.piwik.siteId }}"
                 style="border:0;" alt="" /></p>
     </noscript>
 {% endblock %}


### PR DESCRIPTION
Hardcoding the pixel check to http causes insecure content issues with gitbook sites hosted on https. Just using // should allow how the site is loaded to decide between http or https.